### PR TITLE
chore: add --ignore-engines to yarnExtraArgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,10 @@ npm version patch
 git push
 git push --tags
 ```
+
+## Caveats
+
+If you're using a node-version that's too new (>16.x), you might need to set this env-var if you get errors bundling the app. 
+```sh 
+export NODE_OPTIONS=--openssl-legacy-provider
+```

--- a/build.sbt
+++ b/build.sbt
@@ -68,6 +68,9 @@ lazy val cli = project
       "bufferutil",
       "utf-8-validate",
     ),
+    Compile / yarnExtraArgs ++= Seq(
+      "--ignore-engines"
+    ),
     Compile / npmDependencies      ++= Seq(
       /* "@types/oidc-provider" -> "^7.8.2", // TODO: crashes scalablytyped */
       "express"        -> "^4.17.3",


### PR DESCRIPTION
fixes build when node-version of host is > 16.x. oidc-provider in use requires older version of node, but no time for updating (and potentially fixing breaking changes)